### PR TITLE
Added 404 instead of 500 error when no entity is found

### DIFF
--- a/__tests__/entity_api.test.ts
+++ b/__tests__/entity_api.test.ts
@@ -98,6 +98,17 @@ describe("Entity API tests", () => {
         }
     });
 
+    test("Get non-existent spec-only entity should fail", async (done) => {
+        expect.assertions(2);
+        try {
+            await entityApi.get(`/${ providerPrefix }/${ kind_name }/${ uuid() }`);
+        } catch (e) {
+            expect(e.response.status).toBe(404);
+            expect(e.response.data).not.toBeUndefined();
+            done();
+        }
+    });
+
     test("Filter entity", async (done) => {
         try {
             let res = await entityApi.post(`${ providerPrefix }/${ kind_name }/filter`, {

--- a/src/databases/spec_db_mongo.ts
+++ b/src/databases/spec_db_mongo.ts
@@ -2,7 +2,7 @@ import * as core from "../core";
 import { Entity } from "../core";
 import { Spec_DB } from "./spec_db_interface";
 import { Collection, Db } from "mongodb";
-import { ConflictingEntityError } from "./utils/errors";
+import { ConflictingEntityError, EntityNotFoundError } from "./utils/errors";
 
 export class Spec_DB_Mongo implements Spec_DB {
     collection: Collection;
@@ -69,7 +69,7 @@ export class Spec_DB_Mongo implements Spec_DB {
             "metadata.deleted_at": null
         });
         if (result === null) {
-            throw new Error("Entity not found")
+            throw new EntityNotFoundError(entity_ref.kind, entity_ref.uuid)
         }
         return [result.metadata, result.spec];
     }

--- a/src/databases/utils/errors.ts
+++ b/src/databases/utils/errors.ts
@@ -1,4 +1,5 @@
-import {Metadata, Spec} from "../../core";
+import { Metadata, Spec, uuid4 } from "../../core";
+import { Kind } from "../../papiea";
 
 export class ConflictingEntityError extends Error {
 
@@ -9,5 +10,17 @@ export class ConflictingEntityError extends Error {
         super(msg);
         this.existing_metadata = metadata;
         this.existing_spec = spec;
+    }
+}
+
+export class EntityNotFoundError extends Error {
+
+    uuid: uuid4;
+    kind: string;
+
+    constructor(kind: string, uuid: uuid4) {
+        super();
+        this.kind = kind;
+        this.uuid = uuid;
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { MongoConnection } from "./databases/mongo";
 import { createEntityRoutes } from "./entity/entity_routes";
 import { EntityAPI, ProcedureInvocationError } from "./entity/entity_api_impl";
 import { ValidationError, Validator } from "./validator";
+import { EntityNotFoundError } from "./databases/utils/errors";
 
 declare var process: {
     env: {
@@ -43,6 +44,10 @@ async function setUpApplication(): Promise<express.Express> {
             case ProcedureInvocationError:
                 res.status(err.status);
                 res.json({ errors: err.errors });
+                return;
+            case EntityNotFoundError:
+                res.status(404);
+                res.json({"error": `Entity with kind: ${err.kind}, uuid: ${err.uuid} not found`});
                 return;
             default:
                 res.status(500);


### PR DESCRIPTION
If we go with propagating internal server error a.k.a 500, we are leaking some info as well as not giving informative error