### PR TITLE
Move validation from routes to API impl classes

### DIFF
--- a/__tests__/entity_api.test.ts
+++ b/__tests__/entity_api.test.ts
@@ -78,6 +78,7 @@ describe("Entity API tests", () => {
                     y: 11
                 }
             });
+            done.fail();
         } catch (err) {
             const res = err.response;
             expect(res.status).toEqual(400);
@@ -102,6 +103,7 @@ describe("Entity API tests", () => {
         expect.assertions(2);
         try {
             await entityApi.get(`/${ providerPrefix }/${ kind_name }/${ uuid() }`);
+            done.fail();
         } catch (e) {
             expect(e.response.status).toBe(404);
             expect(e.response.data).not.toBeUndefined();
@@ -356,9 +358,16 @@ describe("Entity API tests", () => {
     });
 
     test("Update entity with malformed spec should fail", async (done) => {
-        expect.assertions(2);
+        expect.assertions(3);
         try {
-            await entityApi.put(`/${providerPrefix}/${kind_name}/${entity_metadata.uuid}`, {
+            const { data: { metadata, spec } } = await entityApi.post(`/${providerPrefix}/${kind_name}`, {
+                spec: {
+                    x: 10,
+                    y: 11
+                }
+            });
+            expect(metadata).not.toBeUndefined();
+            await entityApi.put(`/${providerPrefix}/${kind_name}/${metadata.uuid}`, {
                 spec: {
                     x: "Totally not a number",
                     y: 21
@@ -367,6 +376,7 @@ describe("Entity API tests", () => {
                     spec_version: 1
                 }
             });
+            done.fail();
         } catch (err) {
             const res = err.response;
             expect(res.status).toEqual(400);

--- a/__tests__/provider_api.test.ts
+++ b/__tests__/provider_api.test.ts
@@ -25,26 +25,34 @@ const entityApi = axios.create({
 describe("Provider API tests", () => {
     const providerPrefix = "test_provider";
     const providerVersion = "0.1.0";
+    
     test("Non-existent route", done => {
         providerApi.delete(`/abc`).then(() => done.fail()).catch(() => done());
     });
+    
     test("Register provider", done => {
         const provider: Provider = { prefix: providerPrefix, version: providerVersion, kinds: [] };
         providerApi.post('/', provider).then(() => done()).catch(done.fail);
     });
+    
     test("Register malformed provider", done => {
         providerApi.post('/', {}).then(() => done.fail()).catch(() => done());
     });
+    
     // TODO(adolgarev): there is no API to list providers
+    
     test("Unregister provider", done => {
         providerApi.delete(`/${providerPrefix}/${providerVersion}`).then(() => done()).catch(done.fail);
     });
+    
     test("Unregister non-existend provider", done => {
         providerApi.delete(`/${providerPrefix}/${providerVersion}`).then(() => done.fail()).catch(() => done());
     });
+    
     test("Unregister never existed provider", done => {
         providerApi.delete(`/123/123`).then(() => done.fail()).catch(() => done());
     });
+    
     test("Update status", async done => {
         try {
             const provider: Provider = getProviderWithSpecOnlyEnitityKindNoOperations();
@@ -95,6 +103,7 @@ describe("Provider API tests", () => {
                 },
                 status: { x: 11, y: "Totally not a number" }
             });
+            done.fail();
         } catch (err) {
             done();
         }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "main.js",
   "scripts": {
     "start": "ts-node src/main.ts",
-    "test": "jest --coverage",
-    "test-ci": "jest --coverage --ci --reporters=default --reporters=jest-junit",
+    "test": "jest --runInBand --coverage",
+    "test-ci": "jest --runInBand --coverage --ci --reporters=default --reporters=jest-junit",
     "dev": "./node_modules/nodemon/bin/nodemon.js",
     "test-watch": "jest --watchAll",
     "build-clj": "cd papiea-lib-clj && lein cljsbuild once",

--- a/src/entity/entity_api_interface.ts
+++ b/src/entity/entity_api_interface.ts
@@ -1,7 +1,7 @@
 import { Kind } from "../papiea";
 import { Metadata, Spec, Status, uuid4 } from "../core";
 
-export interface EntityApiInterface {
+export interface Entity_API {
     get_kind(prefix: string, kind: string): Promise<Kind>
 
     save_entity(kind: Kind, spec_description: Spec, status_description?: Status): Promise<[Metadata, Spec]>

--- a/src/entity/entity_routes.ts
+++ b/src/entity/entity_routes.ts
@@ -1,11 +1,11 @@
 import * as asyncHandler from 'express-async-handler'
 import * as express from "express";
-import { EntityAPI } from "./entity_api_impl";
+import { Entity_API } from "./entity_api_interface";
 import { Router } from "express";
 import { Kind } from "../papiea";
 
 
-export function createEntityRoutes(entity_api: EntityAPI): Router {
+export function createEntityRoutes(entity_api: Entity_API): Router {
     const router = express.Router();
 
     const kind_middleware = asyncHandler(async (req, res, next) => {
@@ -15,19 +15,6 @@ export function createEntityRoutes(entity_api: EntityAPI): Router {
         } else {
             throw new Error("Entity kind already exists in the request");
         }
-    });
-
-    const validate_kind_middleware = asyncHandler(async (req, res, next) => {
-        const kind: Kind = req.params.entity_kind;
-        try{
-            entity_api.validate_spec(req.body.spec, kind.kind_structure);
-            next();
-        }
-        catch (e) {
-            console.error("Validate failed:", e)
-            next(e)
-        }
-        
     });
 
     const filterEntities = async function (kind: Kind, filter: any): Promise<any> {
@@ -74,7 +61,7 @@ export function createEntityRoutes(entity_api: EntityAPI): Router {
         const [_, status] = await entity_api.get_entity_status(req.params.entity_kind, req.params.uuid);
         res.json({ "metadata": metadata, "spec": spec, "status": status });
     }));
-//{"status": {"cluster_reference":{"name":{"$regex":".*[i|I][t|T][s|S][a|A][b|B][o|O][y|Y].*"}}}}
+
     router.post("/:prefix/:kind/filter", kind_middleware, asyncHandler(async (req, res) => {
         const filter: any = {};
         if (req.body.spec) {
@@ -96,13 +83,13 @@ export function createEntityRoutes(entity_api: EntityAPI): Router {
         res.json(await filterEntities(req.params.entity_kind, filter));
     }));
 
-    router.put("/:prefix/:kind/:uuid", kind_middleware, validate_kind_middleware, asyncHandler(async (req, res) => {
+    router.put("/:prefix/:kind/:uuid", kind_middleware, asyncHandler(async (req, res) => {
         const request_metadata = req.body.metadata;
         const [metadata, spec] = await entity_api.update_entity_spec(req.params.uuid, request_metadata.spec_version, req.params.entity_kind, req.body.spec);
         res.json({ "metadata": metadata, "spec": spec });
     }));
 
-    router.post("/:prefix/:kind", kind_middleware, validate_kind_middleware, asyncHandler(async (req, res) => {
+    router.post("/:prefix/:kind", kind_middleware, asyncHandler(async (req, res) => {
         if (req.params.status) {
             const [metadata, spec] = await entity_api.save_entity(req.params.entity_kind, req.body.spec, req.body.metadata);
             res.json({ "metadata": metadata, "spec": spec });

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import createProviderAPIRouter from "./provider/provider_routes";
 import { Provider_API_Impl } from "./provider/provider_api_impl";
 import { MongoConnection } from "./databases/mongo";
 import { createEntityRoutes } from "./entity/entity_routes";
-import { EntityAPI, ProcedureInvocationError } from "./entity/entity_api_impl";
+import { Entity_API_Impl, ProcedureInvocationError } from "./entity/entity_api_impl";
 import { ValidationError, Validator } from "./validator";
 import { EntityNotFoundError } from "./databases/utils/errors";
 
@@ -30,7 +30,7 @@ async function setUpApplication(): Promise<express.Express> {
     const statusDb = await mongoConnection.get_status_db();
     const validator = new Validator();
     app.use('/provider', createProviderAPIRouter(new Provider_API_Impl(providerDb, statusDb)));
-    app.use('/entity', createEntityRoutes(new EntityAPI(statusDb, specDb, providerDb, validator)));
+    app.use('/entity', createEntityRoutes(new Entity_API_Impl(statusDb, specDb, providerDb, validator)));
     app.use('/api-docs', createAPIDocsRouter('/api-docs', new ApiDocsGenerator(providerDb)));
     app.use(function (err: any, req: any, res: any, next: any) {
         if (res.headersSent) {

--- a/src/provider/provider_api_impl.ts
+++ b/src/provider/provider_api_impl.ts
@@ -4,7 +4,7 @@ import { Provider_API, Provider_Power } from "./provider_api_interface";
 import { Provider_DB } from "../databases/provider_db_interface";
 import { Status_DB } from "../databases/status_db_interface";
 import { Provider } from "../papiea";
-import { Data_Description, Status } from "../core";
+import { Status } from "../core";
 import { Validator } from "../validator";
 
 export class Provider_API_Impl implements Provider_API {
@@ -27,6 +27,7 @@ export class Provider_API_Impl implements Provider_API {
     }
 
     async update_status(context: any, entity_ref: core.Entity_Reference, status: core.Status): Promise<void> {
+        await this.validate_status(entity_ref, status);
         return this.statusDb.update_status(entity_ref, status);
     }
 
@@ -44,8 +45,13 @@ export class Provider_API_Impl implements Provider_API {
         return this.providerDb.get_provider_by_kind(kind_name)
     }
 
-    validate_status(status: Status, kind_structure: Data_Description) {
-        const schemas: any = Object.assign({}, kind_structure);
-        this.validator.validate(status, Object.values(kind_structure)[0], schemas);
+    private async validate_status(entity_ref: core.Entity_Reference, status: Status) {
+        const provider: Provider = await this.get_provider_by_kind(entity_ref.kind);
+        const kind = provider.kinds.find(kind => kind.name === entity_ref.kind);
+        if (kind === undefined) {
+            throw new Error("Kind not found");
+        }
+        const schemas: any = Object.assign({}, kind.kind_structure);
+        this.validator.validate(status, Object.values(kind.kind_structure)[0], schemas);
     }
 }

--- a/src/provider/provider_api_interface.ts
+++ b/src/provider/provider_api_interface.ts
@@ -30,6 +30,4 @@ export interface Provider_API {
     power(provider_prefix: string, version: core.Version, power_state: Provider_Power): Promise<void>;
 
     get_provider_by_kind(kind_name: string): Promise<Provider>;
-
-    validate_status(status: Status, kind_structure: Data_Description): void;
 }

--- a/src/provider/provider_routes.ts
+++ b/src/provider/provider_routes.ts
@@ -1,20 +1,10 @@
 import * as express from "express";
 import { Provider_API, Provider_Power } from "./provider_api_interface";
 import * as asyncHandler from 'express-async-handler'
-import { Provider } from "../papiea";
+
 
 export default function createProviderAPIRouter(providerApi: Provider_API) {
     const providerApiRouter = express.Router();
-
-    const provider_validate_status_middleware = asyncHandler(async (req, res, next) => {
-        const provider: Provider = await providerApi.get_provider_by_kind(req.body.entity_ref.kind);
-        const kind = provider.kinds.find(kind => kind.name === req.body.entity_ref.kind);
-        if (kind === undefined) {
-            throw new Error("Kind not found");
-        }
-        providerApi.validate_status(req.body.status, kind.kind_structure);
-        next();
-    });
 
     providerApiRouter.post('/', asyncHandler(async (req, res) => {
         const result = await providerApi.register_provider(req.body);
@@ -26,7 +16,7 @@ export default function createProviderAPIRouter(providerApi: Provider_API) {
         res.json("OK")
     }));
 
-    providerApiRouter.post('/update_status', provider_validate_status_middleware, asyncHandler(async (req, res) => {
+    providerApiRouter.post('/update_status', asyncHandler(async (req, res) => {
         await providerApi.update_status(req.body.context, req.body.entity_ref, req.body.status);
         res.json("OK")
     }));


### PR DESCRIPTION
To keep interfaces more clean and increase cohesion moved validation to Entity and Provider API impl classes