### PR TITLE
Call procedure auth tests

### DIFF
--- a/papiea-engine/__tests__/entity_api_auth.test.ts
+++ b/papiea-engine/__tests__/entity_api_auth.test.ts
@@ -462,7 +462,7 @@ describe("Entity API auth tests", () => {
             });
             const { data: { token } } = await providerApi.get(`/${provider.prefix}/${provider.version}/auth/login`);
             await providerApiAdmin.post(`/${provider.prefix}/${provider.version}/auth`, {
-                policy: `p, alice, owner, ${kind_name}, read, allow\np, alice, owner, ${kind_name}, callmovex, allow`
+                policy: `p, alice, owner, ${kind_name}, read, allow\np, alice, owner, ${kind_name}, call_movex, allow`
             });
             await entityApi.post(`/${provider.prefix}/${provider.version}/${kind_name}/${entity_metadata.uuid}/procedure/moveX`, { input: 5 },
                 { headers: { 'Authorization': 'Bearer ' + token } }

--- a/papiea-engine/src/auth/authz.ts
+++ b/papiea-engine/src/auth/authz.ts
@@ -35,7 +35,7 @@ export const ReadAction = new Action('read'),
     InactivateS2SKeyAction = new Action('inactivate_key');
 
 export function CallProcedureByNameAction(procedureName: string) {
-    return new Action('call' + procedureName.toLowerCase());
+    return new Action('call_' + procedureName.toLowerCase());
 }
 
 function mapAsync<T, U>(array: T[], callbackfn: (value: T, index: number, array: T[]) => Promise<U>): Promise<U[]> {

--- a/papiea-engine/src/auth/authz.ts
+++ b/papiea-engine/src/auth/authz.ts
@@ -35,7 +35,7 @@ export const ReadAction = new Action('read'),
     InactivateS2SKeyAction = new Action('inactivate_key');
 
 export function CallProcedureByNameAction(procedureName: string) {
-    return new Action('call' + procedureName);
+    return new Action('call' + procedureName.toLowerCase());
 }
 
 function mapAsync<T, U>(array: T[], callbackfn: (value: T, index: number, array: T[]) => Promise<U>): Promise<U[]> {

--- a/papiea-engine/src/auth/casbin.ts
+++ b/papiea-engine/src/auth/casbin.ts
@@ -29,7 +29,7 @@ export class CasbinAuthorizer extends Authorizer {
                 throw new PermissionDeniedError();
             }
         } catch (e) {
-            console.error(e);
+            console.error("CasbinAuthorizer checkPermission error", e);
             throw new PermissionDeniedError();
         }
     }

--- a/papiea-engine/src/auth/casbin.ts
+++ b/papiea-engine/src/auth/casbin.ts
@@ -24,7 +24,12 @@ export class CasbinAuthorizer extends Authorizer {
     }
 
     async checkPermission(user: UserAuthInfo, object: any, action: Action): Promise<void> {
-        if (!this.enforcer.enforce(user, object, action.getAction())) {
+        try {
+            if (!this.enforcer.enforce(user, object, action.getAction())) {
+                throw new PermissionDeniedError();
+            }
+        } catch (e) {
+            console.error(e);
             throw new PermissionDeniedError();
         }
     }


### PR DESCRIPTION
* If one uses a policy
`p, alice, owner, ${kind_name}, *, allow`
this means that owner of the entity may do all actions on top of it, including all procedure calls
* To be more explicit
```
p, alice, owner, ${kind_name}, read, allow
p, alice, owner, ${kind_name}, callmovex, allow
````
This allows alice to call moveX entity procedure for entities of which she is an owner, note that read permission is also required as entity will be read and given to the procedure
* auth for kind and provider level procedures does not work with current casbin model for provider-user because there is no owner or tenant on kind or provider level
* provider-admin can call all kind and provider procedures of his provider