### PR TITLE
Provider-admin rights refined

### DIFF
--- a/papiea-engine/src/auth/authz.ts
+++ b/papiea-engine/src/auth/authz.ts
@@ -168,17 +168,19 @@ export class AdminAuthorizer extends Authorizer {
             return;
         }
         if (action === CreateS2SKeyAction) {
-            if (object.owner !== user.owner || object.provider_prefix !== user.provider_prefix) {
+            // object.extension contains UserInfo which will be used when s2s key is passed
+            // check who can talk on behalf of whom
+            if (object.owner !== user.owner
+                || object.provider_prefix !== user.provider_prefix
+                || object.extension.provider_prefix !== user.provider_prefix
+                || object.extension.is_admin) {
                 throw new PermissionDeniedError();
             }
             if (user.is_provider_admin) {
                 return;
             }
-            // object.extension contains UserInfo which will be used when s2s key is passed
-            // check who can talk on behalf of whom
-            if (object.extension.is_admin || object.extension.is_provider_admin
-                || (object.extension.provider_prefix !== user.provider_prefix)
-                || (object.extension.owner && object.extension.owner !== user.owner)) {
+            if (object.extension.is_provider_admin
+                || object.extension.owner !== user.owner) {
                 throw new PermissionDeniedError();
             }
             return;

--- a/papiea-engine/src/provider/provider_api_impl.ts
+++ b/papiea-engine/src/provider/provider_api_impl.ts
@@ -115,6 +115,17 @@ export class Provider_API_Impl implements Provider_API {
     }
 
     async create_key(user: UserAuthInfo, name: string, owner: string, provider_prefix: string, extension?: any, key?: string): Promise<S2S_Key> {
+        // - name is not mandatory, displayed in UI
+        // - owner is the owner of the key (usually email),
+        // it is not unique, different providers may have same owner
+        // - provider_prefix determines provider key belongs to,
+        // tuple (owner, provider_prefix) determines a set of keys owner owns for given provider
+        // - extension is a UserAuthInfo which will be used when s2s key provided, that is 
+        // if s2skey A is provided in Authoriation
+        // then casbin will do all checks against A.extension.owner,
+        // A.extension.provider_prefix, A.extension.tenant, etc.
+        // In other words user with s2skey A talks on behalf of user in A.extension
+        // All rules who can talk on behalf of whom are defined in AdminAuthorizer
         const s2skey: S2S_Key = {
             name: name,
             owner: owner,


### PR DESCRIPTION
Resolves #201

    ✓ Admin should create s2s key for provider-admin (49ms)
    ✓ Admin should create s2s key for provider-admin with key provided (10ms)
    ✓ Provider-admin should register and unregister provider (14ms)
    ✓ Provider-admin should not register provider with another prefix (7ms)
    ✓ Provider-admin should update status (35ms)
    ✓ Provider-admin should not update status for provider with another prefix (19ms)
    ✓ Provider-admin should not create s2s key for admin (7ms)
    ✓ Provider-admin should not create s2s key with another provider prefix (7ms)
    ✓ Provider-admin should create s2s key for another provider-admin (9ms)
    ✓ Provider-admin should create s2s key for provider-user (8ms)
    ✓ Provider-admin should not create s2s key for provider-user with provider-user owner (8ms)
    ✓ Provider-user should list only his s2s keys (47ms)
    ✓ Provider-admin should list only his s2s keys not including provider-users (20ms)
