### PR TITLE
Use relative url for api-docs

### DIFF
--- a/papiea-engine/src/main.ts
+++ b/papiea-engine/src/main.ts
@@ -60,7 +60,7 @@ async function setUpApplication(): Promise<express.Express> {
     const entityApiAuthorizer: Authorizer = new PerProviderAuthorizer(providerApi, new ProviderCasbinAuthorizerFactory());
     app.use('/provider', createProviderAPIRouter(providerApi));
     app.use('/services', createEntityAPIRouter(new Entity_API_Impl(statusDb, specDb, providerApi, validator, entityApiAuthorizer)));
-    app.use('/api-docs', createAPIDocsRouter('/api-docs', new ApiDocsGenerator(providerDb)));
+    app.use('/api-docs', createAPIDocsRouter('api-docs', new ApiDocsGenerator(providerDb)));
     app.use(function (err: any, req: any, res: any, next: any) {
         if (res.headersSent) {
             return next(err);


### PR DESCRIPTION
because proxy may change the url like /papiea/api-docs

Resolves #196 