### PR TITLE
Changed logger to be pretty printed & fixed a bug and added test

### DIFF
--- a/papiea-engine/__tests__/logging_tests/logger.test.ts
+++ b/papiea-engine/__tests__/logging_tests/logger.test.ts
@@ -1,0 +1,21 @@
+import Logger from "../../src/logger_interface"
+import { WinstonLogger } from "../../src/logger"
+import { readFileSync, watch } from "fs"
+import { resolve } from "path"
+
+describe("Logger tests", () => {
+    test("Logger can work with a list of parameters", () => {
+        const logger: Logger = new WinstonLogger("info", "logger_test.log")
+        logger.error({ one: "error" }, { two: "errors" }, { three: "errors" })
+        // First change is creating file, second one is writing to the file
+        let change_count = 1
+        const watcher = watch(resolve(__dirname, "../../src/logs"), (event, filename) => {
+            if (filename === "logger_test.log" && change_count === 2) {
+                const content: string = readFileSync(resolve(__dirname, "../../src/logs/logger_test.log"), "utf-8")
+                expect(content).toEqual('{"0":{"two":"errors"},"1":{"three":"errors"},"2":{"Time":"2019-08-21T14:26:41.129Z"},"level":"error","message":{"one":"error"}}\n')
+            }
+            change_count++
+        })
+        watcher.close()
+    })
+})

--- a/papiea-engine/src/logger.ts
+++ b/papiea-engine/src/logger.ts
@@ -1,7 +1,8 @@
-import * as winston from 'winston';
-import { resolve } from "path";
-import { NextFunction, Request } from "express";
-import Logger from './logger_interface';
+import * as winston from 'winston'
+import { resolve } from "path"
+import { NextFunction, Request } from "express"
+import Logger from './logger_interface'
+import { safeJSONParse } from "./utils/utils"
 
 export function getLoggingMiddleware(logger: Logger) {
     return async (req: Request, res: any, next: NextFunction): Promise<void> => {
@@ -33,14 +34,6 @@ export function getLoggingMiddleware(logger: Logger) {
     }
 }
 
-function safeJSONParse(chunk: string) {
-    try {
-        return JSON.parse(chunk);
-    } catch (e) {
-        return undefined;
-    }
-}
-
 export class WinstonLogger implements Logger {
     private logger: winston.Logger;
     private readonly logLevels = ["emerg", "alert", "crit", "error", "warning", "notice", "info", "debug"];
@@ -49,16 +42,22 @@ export class WinstonLogger implements Logger {
         if (!this.isValidLevel(logLevel)) {
             throw new Error("Unsupported logging level");
         }
+        let winstonFormat = winston.format.combine(winston.format.json(), winston.format.prettyPrint());
         this.logger = winston.createLogger({
             levels: winston.config.syslog.levels,
             level: logLevel,
             exitOnError: false,
-            format: winston.format.json(),
+            format: winstonFormat,
             transports: [
-                new winston.transports.File({ filename: logFile ?
-                    resolve(__dirname, `./logs/${logFile}`) :
-                    resolve(__dirname, `./logs/papiea_${logLevel}.log`) }),
-                new winston.transports.Console()
+                new winston.transports.File({
+                    filename: logFile ?
+                        resolve(__dirname, `./logs/${ logFile }`) :
+                        resolve(__dirname, `./logs/papiea_${ logLevel }.log`),
+                    format: winston.format.json()
+                }),
+                new winston.transports.Console({
+                    format: winstonFormat
+                })
             ],
         });
     }
@@ -74,43 +73,43 @@ export class WinstonLogger implements Logger {
         this.logger.level = logLevel;
     }
 
-    public emerg(...message: any): void {
-        message["Time"] = new Date();
-        this.logger.emerg(message);
+    public emerg(msg: any, ...messages: any[]): void {
+        messages.push({ Time: new Date() })
+        this.logger.emerg(msg, messages);
     }
 
-    public alert(...message: any): void {
-        message["Time"] = new Date();
-        this.logger.alert(message);
+    public alert(msg: any, ...messages: any[]): void {
+        messages.push({ Time: new Date() })
+        this.logger.alert(msg, messages);
     }
 
-    public crit(...message: any): void {
-        message["Time"] = new Date();
-        this.logger.crit(message);
+    public crit(msg: any, ...messages: any[]): void {
+        messages.push({ Time: new Date() })
+        this.logger.crit(msg, messages);
     }
 
-    public error(...message: any): void {
-        message["Time"] = new Date();
-        this.logger.error(message);
+    public error(msg: any, ...messages: any[]): void {
+        messages.push({ Time: new Date() })
+        this.logger.error(msg, messages);
     }
 
-    public warning(...message: any): void {
-        message["Time"] = new Date();
-        this.logger.warning(message);
+    public warning(msg: any, ...messages: any[]): void {
+        messages.push({ Time: new Date() })
+        this.logger.warning(msg, messages);
     }
 
-    public notice(...message: any): void {
-        message["Time"] = new Date();
-        this.logger.notice(message);
+    public notice(msg: any, ...messages: any[]): void {
+        messages.push({ Time: new Date() })
+        this.logger.notice(msg, messages);
     }
 
-    public info(...message: any): void {
-        message["Time"] = new Date();
-        this.logger.info(message);
+    public info(msg: any, ...messages: any[]): void {
+        messages.push({ Time: new Date() })
+        this.logger.info(msg, messages);
     }
 
-    public debug(...message: any): void {
-        message["Time"] = new Date();
-        this.logger.debug(message);
+    public debug(msg: any, ...messages: any[]): void {
+        messages.push({ Time: new Date() })
+        this.logger.debug(msg, messages);
     }
 }

--- a/papiea-engine/src/logger.ts
+++ b/papiea-engine/src/logger.ts
@@ -40,7 +40,9 @@ export class WinstonLogger implements Logger {
 
     constructor(logLevel: string, logFile?: string) {
         if (!this.isValidLevel(logLevel)) {
-            throw new Error("Unsupported logging level");
+            this.error(`Unsupported logging level: ${logLevel}`)
+            // convert message to "warning", for lack of better knowledge
+            logLevel = "warning"
         }
         let winstonFormat = winston.format.combine(winston.format.json(), winston.format.prettyPrint());
         this.logger = winston.createLogger({
@@ -53,7 +55,7 @@ export class WinstonLogger implements Logger {
                     filename: logFile ?
                         resolve(__dirname, `./logs/${ logFile }`) :
                         resolve(__dirname, `./logs/papiea_${ logLevel }.log`),
-                    format: winston.format.json()
+                    format: winstonFormat
                 }),
                 new winston.transports.Console({
                     format: winstonFormat

--- a/papiea-engine/src/logger_interface.ts
+++ b/papiea-engine/src/logger_interface.ts
@@ -2,19 +2,19 @@ export default interface Logger {
 
     setLoggingLevel(logLevel: string): void
 
-    emerg(...message: any): void
+    emerg(msg: any, ...messages: any[]): void
 
-    alert(...message: any): void
+    alert(msg: any, ...messages: any[]): void
 
-    crit(...message: any): void
+    crit(msg: any, ...messages: any[]): void
 
-    error(...message: any): void
+    error(msg: any, ...messages: any[]): void
 
-    warning(...message: any): void
+    warning(msg: any, ...messages: any[]): void
 
-    notice(...message: any): void
+    notice(msg: any, ...messages: any[]): void
 
-    info(...message: any): void
+    info(msg: any, ...messages: any[]): void
 
-    debug(...message: any): void
+    debug(msg: any, ...messages: any[]): void
 }

--- a/papiea-engine/src/utils/utils.ts
+++ b/papiea-engine/src/utils/utils.ts
@@ -72,10 +72,11 @@ export function isEmpty(obj: any) {
     return true;
 }
 
-export function safeJSONParse(chunk: string) {
+export function safeJSONParse(chunk: string): Object | null {
     try {
         return JSON.parse(chunk)
     } catch (e) {
-        return undefined
+        console.error(`Safe json parse failed: ${e}, Falling back to undefined`)
+        return null
     }
 }

--- a/papiea-engine/src/utils/utils.ts
+++ b/papiea-engine/src/utils/utils.ts
@@ -1,5 +1,5 @@
-import { SortParams } from "../entity/entity_api_impl";
-import { ValidationError } from "../errors/validation_error";
+import { SortParams } from "../entity/entity_api_impl"
+import { ValidationError } from "../errors/validation_error"
 
 function validatePaginationParams(offset: number | undefined, limit: number | undefined) {
     if (offset) {
@@ -70,4 +70,12 @@ export function isEmpty(obj: any) {
             return false;
     }
     return true;
+}
+
+export function safeJSONParse(chunk: string) {
+    try {
+        return JSON.parse(chunk)
+    } catch (e) {
+        return undefined
+    }
 }


### PR DESCRIPTION
resolves #294 
New logs in console look like the following:
```
{  
   "0":{  
      "two":"errors"
   },
   "1":{  
      "three":"errors"
   },
   "2":{  
      "Time":"2019-08-21T15:00:42.118Z"
   },
   "level":"error",
   "message":{  
      "one":"error"
   }
}
```