### PR TITLE
Default variable for PAPIEA_ADMIN_S2S_KEY wasn't working correctly

### DIFF
--- a/papiea-engine/package-lock.json
+++ b/papiea-engine/package-lock.json
@@ -5763,7 +5763,7 @@
       "dependencies": {
         "@types/axios": {
           "version": "0.14.0",
-          "resolved": "https://nutanix.jfrog.io/nutanix/api/npm/npm-virtual/@types/axios/-/axios-0.14.0.tgz",
+          "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
           "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
           "requires": {
             "axios": "*"
@@ -6316,7 +6316,7 @@
         },
         "lodash.isequal": {
           "version": "4.5.0",
-          "resolved": "https://nutanix.jfrog.io/nutanix/api/npm/npm-virtual/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
           "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
           "dev": true
         },

--- a/papiea-engine/src/auth/authn.ts
+++ b/papiea-engine/src/auth/authn.ts
@@ -64,7 +64,7 @@ export function asyncHandler(fn: UserAuthRequestHandler): any {
 
 function getToken(req: any): string | null {
     if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
-        return req.headers.authorization.split(' ')[1];
+        return req.headers.authorization.split(' ')[1] || '';
     } else if (req.query && req.query.token) {
         return req.query.token;
     } else if (req.cookies && req.cookies.token) {


### PR DESCRIPTION
resolves #332 
`const adminKey = process.env.PAPIEA_ADMIN_S2S_KEY || '';`  wasn't working with function getToken(). 
`return req.headers.authorization.split(' ')[1] || '';` was returning `undefined` which is not expected by the function output