### PR TITLE
Added papiea errors to client

### DIFF
--- a/papiea-client/src/entity_client.ts
+++ b/papiea-client/src/entity_client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosPromise, AxiosRequestConfig } from "axios";
-import { Metadata, Spec, Entity_Reference, Entity, EntitySpec, PapieaErrorTypes } from "papiea-core";
+import { Metadata, Spec, Entity_Reference, Entity, EntitySpec, PapieaErrorType } from "papiea-core";
 import {
     BadRequestError,
     ConflictingEntityError,
@@ -16,21 +16,21 @@ function make_request<T = any>(f: (url: string, data?: any, config?: AxiosReques
         return f(url, data, config)
     } catch (e) {
         switch (e?.response?.data?.error.type) {
-            case PapieaErrorTypes.ConflictingEntity:
+            case PapieaErrorType.ConflictingEntity:
                 throw new ConflictingEntityError(e.response.data.error.message, e)
-            case PapieaErrorTypes.PermissionDenied:
+            case PapieaErrorType.PermissionDenied:
                 throw new PermissionDeniedError(e.response.data.error.message, e)
-            case PapieaErrorTypes.EntityNotFound:
+            case PapieaErrorType.EntityNotFound:
                 throw new EntityNotFoundError(e.response.data.error.message, e)
-            case PapieaErrorTypes.ProcedureInvocation:
+            case PapieaErrorType.ProcedureInvocation:
                 throw new ProcedureInvocationError(e.response.data.error.message, e)
-            case PapieaErrorTypes.Unauthorized:
+            case PapieaErrorType.Unauthorized:
                 throw new UnauthorizedError(e.response.data.error.message, e)
-            case PapieaErrorTypes.Validation:
+            case PapieaErrorType.Validation:
                 throw new ValidationError(e.response.data.error.message, e)
-            case PapieaErrorTypes.BadRequest:
+            case PapieaErrorType.BadRequest:
                 throw new BadRequestError(e.response.data.error.message, e)
-            case PapieaErrorTypes.ServerError:
+            case PapieaErrorType.ServerError:
                 throw new PapieaServerError(e.response.data.error.message, e)
             default:
                 throw new Error(e)

--- a/papiea-client/src/entity_client.ts
+++ b/papiea-client/src/entity_client.ts
@@ -17,124 +17,133 @@ function make_request<T = any>(f: (url: string, data?: any, config?: AxiosReques
     } catch (e) {
         switch (e?.response?.data?.error.type) {
             case PapieaErrorTypes.ConflictingEntity:
-                throw new ConflictingEntityError(e.response.data.error.message)
+                throw new ConflictingEntityError(e.response.data.error.message, e)
             case PapieaErrorTypes.PermissionDenied:
-                throw new PermissionDeniedError(e.response.data.error.message)
+                throw new PermissionDeniedError(e.response.data.error.message, e)
             case PapieaErrorTypes.EntityNotFound:
-                throw new EntityNotFoundError(e.response.data.error.message)
+                throw new EntityNotFoundError(e.response.data.error.message, e)
             case PapieaErrorTypes.ProcedureInvocation:
-                throw new ProcedureInvocationError(e.response.data.error.message)
+                throw new ProcedureInvocationError(e.response.data.error.message, e)
             case PapieaErrorTypes.Unauthorized:
-                throw new UnauthorizedError(e.response.data.error.message)
+                throw new UnauthorizedError(e.response.data.error.message, e)
             case PapieaErrorTypes.Validation:
-                throw new ValidationError(e.response.data.error.message)
+                throw new ValidationError(e.response.data.error.message, e)
             case PapieaErrorTypes.BadRequest:
-                throw new BadRequestError(e.response.data.error.message)
+                throw new BadRequestError(e.response.data.error.message, e)
             case PapieaErrorTypes.ServerError:
-                throw new PapieaServerError(e.response.data.error.message)
+                throw new PapieaServerError(e.response.data.error.message, e)
             default:
                 throw new Error(e)
         }
     }
 }
 
-async function create_entity(provider: string, kind: string, version: string, request_spec: Spec, papiea_url: string,meta_extension:any, s2skey: string): Promise<EntitySpec> {
+async function create_entity(provider: string, kind: string, version: string, request_spec: Spec, papiea_url: string, meta_extension: any, s2skey: string): Promise<EntitySpec> {
     const payload = {
         spec: request_spec,
-        ...(meta_extension) && {metadata: {extension: meta_extension}}
+        ...(meta_extension) && { metadata: { extension: meta_extension } }
     }
-    const { data: { metadata, spec } } = await make_request(axios.post, `${papiea_url}/services/${provider}/${version}/${kind}`, payload, {headers:{"Authorization": `Bearer ${s2skey}`}});
+    const { data: { metadata, spec } } = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }`, payload, { headers: { "Authorization": `Bearer ${ s2skey }` } });
     return { metadata, spec };
 }
 
 async function create_entity_with_meta(provider: string, kind: string, version: string, meta: Partial<Metadata>, request_spec: Spec, papiea_url: string, s2skey: string): Promise<EntitySpec> {
-    const { data: { metadata, spec } } = await make_request(axios.post, `${papiea_url}/services/${provider}/${version}/${kind}`, {
+    const { data: { metadata, spec } } = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }`, {
         spec: request_spec,
         metadata: meta
-    }, {headers:{"Authorization": `Bearer ${s2skey}`}});
+    }, { headers: { "Authorization": `Bearer ${ s2skey }` } });
     return { metadata, spec };
 }
 
 async function update_entity(provider: string, kind: string, version: string, request_spec: Spec, request_metadata: Metadata, papiea_url: string, s2skey: string): Promise<EntitySpec> {
-    const { data: { metadata, spec } } = await make_request(axios.put, `${papiea_url}/services/${provider}/${version}/${kind}/${request_metadata.uuid}`, {
+    const { data: { metadata, spec } } = await make_request(axios.put, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/${ request_metadata.uuid }`, {
         spec: request_spec,
         metadata: {
             spec_version: request_metadata.spec_version
         }
-    }, {headers:{"Authorization": `Bearer ${s2skey}`}});
+    }, { headers: { "Authorization": `Bearer ${ s2skey }` } });
     return { metadata, spec }
 }
 
 async function get_entity(provider: string, kind: string, version: string, entity_reference: Entity_Reference, papiea_url: string, s2skey: string): Promise<Entity> {
-    const { data: { metadata, spec, status } } = await make_request(axios.get, `${papiea_url}/services/${provider}/${version}/${kind}/${entity_reference.uuid}`,
-    {headers:{"Authorization": `Bearer ${s2skey}`}});
+    const { data: { metadata, spec, status } } = await make_request(axios.get, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/${ entity_reference.uuid }`,
+        { headers: { "Authorization": `Bearer ${ s2skey }` } });
     return { metadata, spec, status }
 }
 
 async function delete_entity(provider: string, kind: string, version: string, entity_reference: Entity_Reference, papiea_url: string, s2skey: string): Promise<void> {
-    await make_request(axios.delete, `${papiea_url}/services/${provider}/${version}/${kind}/${entity_reference.uuid}`, {headers:{"Authorization": `Bearer ${s2skey}`}});
+    await make_request(axios.delete, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/${ entity_reference.uuid }`, { headers: { "Authorization": `Bearer ${ s2skey }` } });
 }
 
 async function invoke_entity_procedure(provider: string, kind: string, version: string, procedure_name: string, input: any, entity_reference: Entity_Reference, papiea_url: string, s2skey: string): Promise<any> {
-    const res = await make_request(axios.post, `${papiea_url}/services/${provider}/${version}/${kind}/${entity_reference.uuid}/procedure/${procedure_name}`, {input}, {headers:{"Authorization": `Bearer ${s2skey}`}});
+    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/${ entity_reference.uuid }/procedure/${ procedure_name }`, { input }, { headers: { "Authorization": `Bearer ${ s2skey }` } });
     return res.data;
 }
 
 async function invoke_kind_procedure(provider: string, kind: string, version: string, procedure_name: string, input: any, papiea_url: string, s2skey: string): Promise<any> {
-    const res = await make_request(axios.post, `${papiea_url}/services/${provider}/${version}/${kind}/procedure/${procedure_name}`, {input}, {headers:{"Authorization": `Bearer ${s2skey}`}});
+    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/procedure/${ procedure_name }`, { input }, { headers: { "Authorization": `Bearer ${ s2skey }` } });
     return res.data;
 }
 
 export async function invoke_provider_procedure(provider: string, version: string, procedure_name: string, input: any, papiea_url: string, s2skey: string): Promise<any> {
-    const res = await make_request(axios.post, `${papiea_url}/services/${provider}/${version}/procedure/${procedure_name}`, {input}, {headers:{"Authorization": `Bearer ${s2skey}`}});
+    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/procedure/${ procedure_name }`, { input }, { headers: { "Authorization": `Bearer ${ s2skey }` } });
     return res.data;
 }
 
 export interface FilterResults {
-    entity_count : number
+    entity_count: number
     results: Entity[]
 }
+
 export async function filter_entity(provider: string, kind: string, version: string, filter: any, papiea_url: string, s2skey: string): Promise<FilterResults> {
-    const res = await make_request(axios.post, `${papiea_url}/services/${provider}/${version}/${kind}/filter/`, filter, {headers:{"Authorization": `Bearer ${s2skey}`}});
+    const res = await make_request(axios.post, `${ papiea_url }/services/${ provider }/${ version }/${ kind }/filter/`, filter, { headers: { "Authorization": `Bearer ${ s2skey }` } });
     return res.data
 }
 
 export interface ProviderClient {
     get_kind(kind: string): EntityCRUD
+
     invoke_procedure(procedure_name: string, input: any): Promise<any>
 }
 
-export function provider_client(papiea_url: string, provider: string, version: string, s2skey?: string, meta_extension?: (s2skey: string)=>any) : ProviderClient {
+export function provider_client(papiea_url: string, provider: string, version: string, s2skey?: string, meta_extension?: (s2skey: string) => any): ProviderClient {
     const the_s2skey = s2skey ?? 'anonymous'
-    return <ProviderClient> {
-        get_kind: (kind: string)=> kind_client(papiea_url, provider, kind, version, the_s2skey, meta_extension),
-        invoke_procedure: (proc_name: string, input: any)=> invoke_provider_procedure(provider, version, proc_name, input, papiea_url, the_s2skey)
+    return <ProviderClient>{
+        get_kind: (kind: string) => kind_client(papiea_url, provider, kind, version, the_s2skey, meta_extension),
+        invoke_procedure: (proc_name: string, input: any) => invoke_provider_procedure(provider, version, proc_name, input, papiea_url, the_s2skey)
     }
 }
 
 // map based crud
 export interface EntityCRUD {
     get(entity_reference: Entity_Reference): Promise<Entity>
+
     create(spec: Spec): Promise<EntitySpec>
+
     create_with_meta(metadata: Partial<Metadata>, spec: Spec): Promise<EntitySpec>
+
     update(metadata: Metadata, spec: Spec): Promise<EntitySpec>
+
     delete(entity_reference: Entity_Reference): Promise<void>
-    filter(filter:any): Promise<FilterResults>
+
+    filter(filter: any): Promise<FilterResults>
+
     invoke_procedure(procedure_name: string, entity_reference: Entity_Reference, input: any): Promise<any>
+
     invoke_kind_procedure(procedure_name: string, input: any): Promise<any>
 }
 
-export function kind_client(papiea_url: string, provider: string, kind: string, version: string, s2skey?: string, meta_extension?: (s2skey: string)=>any): EntityCRUD {
+export function kind_client(papiea_url: string, provider: string, kind: string, version: string, s2skey?: string, meta_extension?: (s2skey: string) => any): EntityCRUD {
     const the_s2skey = s2skey ?? 'anonymous'
     const crudder: EntityCRUD = {
         get: (entity_reference: Entity_Reference) => get_entity(provider, kind, version, entity_reference, papiea_url, the_s2skey),
-        create: (spec: Spec) => create_entity(provider, kind, version, spec, papiea_url, meta_extension ? meta_extension(the_s2skey):undefined, the_s2skey),
-        create_with_meta: (meta: Partial<Metadata>, spec: Spec) => create_entity_with_meta(provider,kind, version, meta, spec, papiea_url, the_s2skey),
+        create: (spec: Spec) => create_entity(provider, kind, version, spec, papiea_url, meta_extension ? meta_extension(the_s2skey) : undefined, the_s2skey),
+        create_with_meta: (meta: Partial<Metadata>, spec: Spec) => create_entity_with_meta(provider, kind, version, meta, spec, papiea_url, the_s2skey),
         update: (metadata: Metadata, spec: Spec) => update_entity(provider, kind, version, spec, metadata, papiea_url, the_s2skey),
         delete: (entity_reference: Entity_Reference) => delete_entity(provider, kind, version, entity_reference, papiea_url, the_s2skey),
-        filter: (filter:any)=>filter_entity(provider, kind, version, filter, papiea_url, the_s2skey),
+        filter: (filter: any) => filter_entity(provider, kind, version, filter, papiea_url, the_s2skey),
         invoke_procedure: (proc_name: string, entity_reference: Entity_Reference, input: any) => invoke_entity_procedure(provider, kind, version, proc_name, input, entity_reference, papiea_url, the_s2skey),
-        invoke_kind_procedure: (proc_name: string, input:any) => invoke_kind_procedure(provider, kind, version, proc_name, input, papiea_url, the_s2skey)
+        invoke_kind_procedure: (proc_name: string, input: any) => invoke_kind_procedure(provider, kind, version, proc_name, input, papiea_url, the_s2skey)
     }
     return crudder
 }
@@ -142,15 +151,17 @@ export function kind_client(papiea_url: string, provider: string, kind: string, 
 // class based crud
 interface EntityObjectCRUD {
     update(spec: Spec): Promise<EntityObjectCRUD>
+
     delete(): Promise<void>
+
     invoke(procedure_name: string, input: any): Promise<any>
 }
 
 export class ImmutableEntityObject implements EntityObjectCRUD {
-    readonly entity: Entity|EntitySpec
+    readonly entity: Entity | EntitySpec
     readonly crud: EntityCRUD
 
-    constructor(e: Entity|EntitySpec, c: EntityCRUD) {
+    constructor(e: Entity | EntitySpec, c: EntityCRUD) {
         this.entity = e
         this.crud = c
     }
@@ -175,16 +186,19 @@ export class ImmutableEntityObject implements EntityObjectCRUD {
 
 interface ImmutableEntityObjectBuilder {
     create(spec: Spec): Promise<ImmutableEntityObject>
-    create_with_meta(meta: Metadata, spec:Spec): Promise<ImmutableEntityObject>
-    filter(filter:any): Promise<ImmutableEntityObject[]>
+
+    create_with_meta(meta: Metadata, spec: Spec): Promise<ImmutableEntityObject>
+
+    filter(filter: any): Promise<ImmutableEntityObject[]>
+
     get(entity_reference: Entity_Reference): Promise<ImmutableEntityObject>
 }
 
 export function objectify(c: EntityCRUD): ImmutableEntityObjectBuilder {
     return {
         create: async (spec: Spec) => new ImmutableEntityObject(await c.create(spec), c).refresh(),
-        create_with_meta: async (meta:Partial<Metadata>, spec:Spec) => new ImmutableEntityObject(await c.create_with_meta(meta, spec), c).refresh(),
-        filter: async (filter:any) => (await c.filter(filter)).results.map(e=>new ImmutableEntityObject(e, c)),
+        create_with_meta: async (meta: Partial<Metadata>, spec: Spec) => new ImmutableEntityObject(await c.create_with_meta(meta, spec), c).refresh(),
+        filter: async (filter: any) => (await c.filter(filter)).results.map(e => new ImmutableEntityObject(e, c)),
         get: async (entity_reference: Entity_Reference) => new ImmutableEntityObject(await c.get(entity_reference), c)
     }
 }

--- a/papiea-client/src/entity_client.ts
+++ b/papiea-client/src/entity_client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosPromise, AxiosRequestConfig } from "axios";
-import { Metadata, Spec, Entity_Reference, Entity, EntitySpec, PapieaErrorType } from "papiea-core";
+import { Metadata, Spec, Entity_Reference, Entity, EntitySpec, PapieaError } from "papiea-core";
 import {
     BadRequestError,
     ConflictingEntityError,
@@ -16,21 +16,21 @@ function make_request<T = any>(f: (url: string, data?: any, config?: AxiosReques
         return f(url, data, config)
     } catch (e) {
         switch (e?.response?.data?.error.type) {
-            case PapieaErrorType.ConflictingEntity:
+            case PapieaError.ConflictingEntity:
                 throw new ConflictingEntityError(e.response.data.error.message, e)
-            case PapieaErrorType.PermissionDenied:
+            case PapieaError.PermissionDenied:
                 throw new PermissionDeniedError(e.response.data.error.message, e)
-            case PapieaErrorType.EntityNotFound:
+            case PapieaError.EntityNotFound:
                 throw new EntityNotFoundError(e.response.data.error.message, e)
-            case PapieaErrorType.ProcedureInvocation:
+            case PapieaError.ProcedureInvocation:
                 throw new ProcedureInvocationError(e.response.data.error.message, e)
-            case PapieaErrorType.Unauthorized:
+            case PapieaError.Unauthorized:
                 throw new UnauthorizedError(e.response.data.error.message, e)
-            case PapieaErrorType.Validation:
+            case PapieaError.Validation:
                 throw new ValidationError(e.response.data.error.message, e)
-            case PapieaErrorType.BadRequest:
+            case PapieaError.BadRequest:
                 throw new BadRequestError(e.response.data.error.message, e)
-            case PapieaErrorType.ServerError:
+            case PapieaError.ServerError:
                 throw new PapieaServerError(e.response.data.error.message, e)
             default:
                 throw new Error(e)

--- a/papiea-client/src/errors/errors.ts
+++ b/papiea-client/src/errors/errors.ts
@@ -1,31 +1,50 @@
-export class ConflictingEntityError extends Error {
+export class PapieaErrorImpl extends Error {
+    original_error: Error
+
+    constructor(message: string, e: Error) {
+        super(message)
+        this.original_error = e
+    }
 
 }
 
-export class EntityNotFoundError extends Error {
+
+// Spec with this version already exists
+export class ConflictingEntityError extends PapieaErrorImpl {
 
 }
 
-export class PermissionDeniedError extends Error {
+// Entity not found on papiea
+export class EntityNotFoundError extends PapieaErrorImpl {
 
 }
 
-export class ProcedureInvocationError extends Error {
+// Token provided doesn't have access rights for the operation
+export class PermissionDeniedError extends PapieaErrorImpl {
 
 }
 
-export class UnauthorizedError extends Error {
+// Error in procedure handler
+export class ProcedureInvocationError extends PapieaErrorImpl {
 
 }
 
-export class ValidationError extends Error {
+// No auth token provided in Authorization header
+export class UnauthorizedError extends PapieaErrorImpl {
 
 }
 
-export class BadRequestError extends Error {
+// Entity spec/status didn't pass validation
+export class ValidationError extends PapieaErrorImpl {
 
 }
 
-export class PapieaServerError extends Error {
+// Wrong data on the request side
+export class BadRequestError extends PapieaErrorImpl {
+
+}
+
+// Something went wrong on papiea
+export class PapieaServerError extends PapieaErrorImpl {
 
 }

--- a/papiea-client/src/errors/errors.ts
+++ b/papiea-client/src/errors/errors.ts
@@ -1,0 +1,31 @@
+export class ConflictingEntityError extends Error {
+
+}
+
+export class EntityNotFoundError extends Error {
+
+}
+
+export class PermissionDeniedError extends Error {
+
+}
+
+export class ProcedureInvocationError extends Error {
+
+}
+
+export class UnauthorizedError extends Error {
+
+}
+
+export class ValidationError extends Error {
+
+}
+
+export class BadRequestError extends Error {
+
+}
+
+export class PapieaServerError extends Error {
+
+}

--- a/papiea-core/src/core.ts
+++ b/papiea-core/src/core.ts
@@ -254,7 +254,7 @@ export interface SessionKey {
     idpToken: any
 }
 
-export enum PapieaErrorTypes {
+export enum PapieaErrorType {
     Validation,
     BadRequest,
     ProcedureInvocation,
@@ -272,7 +272,7 @@ export interface PapieaError {
         errors: { [key: string]: any }[]
         code: number
         message: string
-        type: PapieaErrorTypes
+        type: PapieaErrorType
     }
 }
 

--- a/papiea-core/src/core.ts
+++ b/papiea-core/src/core.ts
@@ -254,7 +254,7 @@ export interface SessionKey {
     idpToken: any
 }
 
-export enum PapieaErrorType {
+export enum PapieaError {
     Validation,
     BadRequest,
     ProcedureInvocation,
@@ -265,15 +265,17 @@ export enum PapieaErrorType {
     ServerError
 }
 
+export interface PapieaResponse {
+    error: PapieaErrorResponse
+}
+
 
 // Modeled after https://developers.google.com/drive/api/v3/handle-errors
-export interface PapieaError {
-    error: {
-        errors: { [key: string]: any }[]
-        code: number
-        message: string
-        type: PapieaErrorType
-    }
+export interface PapieaErrorResponse {
+    errors: { [ key: string ]: any }[]
+    code: number
+    message: string
+    type: PapieaError
 }
 
 export enum Action {

--- a/papiea-core/src/core.ts
+++ b/papiea-core/src/core.ts
@@ -254,13 +254,25 @@ export interface SessionKey {
     idpToken: any
 }
 
+export enum PapieaErrorTypes {
+    Validation,
+    BadRequest,
+    ProcedureInvocation,
+    EntityNotFound,
+    Unauthorized,
+    PermissionDenied,
+    ConflictingEntity,
+    ServerError
+}
+
 
 // Modeled after https://developers.google.com/drive/api/v3/handle-errors
 export interface PapieaError {
     error: {
-        errors: { [key: string]: any }[],
+        errors: { [key: string]: any }[]
         code: number
         message: string
+        type: PapieaErrorTypes
     }
 }
 

--- a/papiea-engine/src/errors/papiea_error_impl.ts
+++ b/papiea-engine/src/errors/papiea_error_impl.ts
@@ -4,21 +4,24 @@ import { ValidationError } from "./validation_error";
 import { ProcedureInvocationError } from "./procedure_invocation_error";
 import { PermissionDeniedError, UnauthorizedError } from "./permission_error";
 import { BadRequestError } from "./bad_request_error";
+import { PapieaErrorTypes } from "papiea-core";
 
 
 export class PapieaErrorImpl implements PapieaError {
     error: {
         errors: { [key: string]: any }[],
         code: number
-        message: string
+        message: string,
+        type: PapieaErrorTypes
     }
 
-    constructor(code: number, errorMsg: string, errors?: { [key: string]: any }[]) {
+    constructor(code: number, errorMsg: string, type: PapieaErrorTypes, errors?: { [key: string]: any }[]) {
         if (errors) {
             this.error = {
                 code,
                 errors,
-                message: errorMsg
+                message: errorMsg,
+                type
             }
         } else {
             this.error = {
@@ -26,7 +29,8 @@ export class PapieaErrorImpl implements PapieaError {
                 errors: [
                     { message: errorMsg }
                 ],
-                message: errorMsg
+                message: errorMsg,
+                type
             }
         }
 
@@ -44,33 +48,34 @@ export class PapieaErrorImpl implements PapieaError {
         let errorPayload: { message: string }[];
         switch (err.constructor) {
             case BadRequestError:
-                return new PapieaErrorImpl(400, "Bad Request",
+                return new PapieaErrorImpl(400, "Bad Request", PapieaErrorTypes.BadRequest,
                     [{ message: err.message }])
             case ValidationError:
                 errorPayload = (err as ValidationError).errors.map(description => {
                     return { message: description }
                 })
-                return new PapieaErrorImpl(400, "Validation failed.", errorPayload)
+                return new PapieaErrorImpl(400, "Validation failed.", PapieaErrorTypes.Validation, errorPayload)
             case ProcedureInvocationError:
-                return new PapieaErrorImpl((err as ProcedureInvocationError).status, "Procedure invocation failed.", (err as ProcedureInvocationError).errors)
+                return new PapieaErrorImpl((err as ProcedureInvocationError).status, "Procedure invocation failed.", PapieaErrorTypes.ProcedureInvocation, (err as ProcedureInvocationError).errors)
             case EntityNotFoundError:
                 return new PapieaErrorImpl(
                     404,
                     "Entity not found.",
-                    [{ message: `Entity with kind: ${(err as EntityNotFoundError).kind}, uuid: ${(err as EntityNotFoundError).uuid} not found` }]
+                    PapieaErrorTypes.EntityNotFound,
+                    [{ message: `Entity with kind: ${(err as EntityNotFoundError).kind}, uuid: ${(err as EntityNotFoundError).uuid} not found` }],
                 )
             case UnauthorizedError:
-                return new PapieaErrorImpl(401, "Unauthorized.")
+                return new PapieaErrorImpl(401, "Unauthorized.", PapieaErrorTypes.Unauthorized)
             case PermissionDeniedError:
-                return new PapieaErrorImpl(403, "Permission denied.")
+                return new PapieaErrorImpl(403, "Permission denied.", PapieaErrorTypes.PermissionDenied)
             case ConflictingEntityError:
                 let conflictingError = err as ConflictingEntityError
                 let metadata = conflictingError.existing_metadata
 
-                return new PapieaErrorImpl(409, `Conflicting Entity: ${metadata.uuid} has version ${metadata.spec_version}`)
+                return new PapieaErrorImpl(409, `Conflicting Entity: ${metadata.uuid} has version ${metadata.spec_version}`, PapieaErrorTypes.ConflictingEntity)
             default:
                 console.log(`Default handle got error: ${err.message}`)
-                return new PapieaErrorImpl(500, err.message)
+                return new PapieaErrorImpl(500, err.message, PapieaErrorTypes.ServerError)
         }
     }
 }

--- a/papiea-engine/src/errors/papiea_error_impl.ts
+++ b/papiea-engine/src/errors/papiea_error_impl.ts
@@ -1,21 +1,21 @@
-import { PapieaError } from "papiea-core";
+import { PapieaResponse } from "papiea-core";
 import { EntityNotFoundError, ConflictingEntityError } from "../databases/utils/errors";
 import { ValidationError } from "./validation_error";
 import { ProcedureInvocationError } from "./procedure_invocation_error";
 import { PermissionDeniedError, UnauthorizedError } from "./permission_error";
 import { BadRequestError } from "./bad_request_error";
-import { PapieaErrorType } from "papiea-core";
+import { PapieaError } from "papiea-core";
 
 
-export class PapieaErrorImpl implements PapieaError {
+export class PapieaErrorResponseImpl implements PapieaResponse {
     error: {
         errors: { [key: string]: any }[],
         code: number
         message: string,
-        type: PapieaErrorType
+        type: PapieaError
     }
 
-    constructor(code: number, errorMsg: string, type: PapieaErrorType, errors?: { [key: string]: any }[]) {
+    constructor(code: number, errorMsg: string, type: PapieaError, errors?: { [key: string]: any }[]) {
         if (errors) {
             this.error = {
                 code,
@@ -48,34 +48,34 @@ export class PapieaErrorImpl implements PapieaError {
         let errorPayload: { message: string }[];
         switch (err.constructor) {
             case BadRequestError:
-                return new PapieaErrorImpl(400, "Bad Request", PapieaErrorType.BadRequest,
+                return new PapieaErrorResponseImpl(400, "Bad Request", PapieaError.BadRequest,
                     [{ message: err.message }])
             case ValidationError:
                 errorPayload = (err as ValidationError).errors.map(description => {
                     return { message: description }
                 })
-                return new PapieaErrorImpl(400, "Validation failed.", PapieaErrorType.Validation, errorPayload)
+                return new PapieaErrorResponseImpl(400, "Validation failed.", PapieaError.Validation, errorPayload)
             case ProcedureInvocationError:
-                return new PapieaErrorImpl((err as ProcedureInvocationError).status, "Procedure invocation failed.", PapieaErrorType.ProcedureInvocation, (err as ProcedureInvocationError).errors)
+                return new PapieaErrorResponseImpl((err as ProcedureInvocationError).status, "Procedure invocation failed.", PapieaError.ProcedureInvocation, (err as ProcedureInvocationError).errors)
             case EntityNotFoundError:
-                return new PapieaErrorImpl(
+                return new PapieaErrorResponseImpl(
                     404,
                     "Entity not found.",
-                    PapieaErrorType.EntityNotFound,
+                    PapieaError.EntityNotFound,
                     [{ message: `Entity with kind: ${(err as EntityNotFoundError).kind}, uuid: ${(err as EntityNotFoundError).uuid} not found` }],
                 )
             case UnauthorizedError:
-                return new PapieaErrorImpl(401, "Unauthorized.", PapieaErrorType.Unauthorized)
+                return new PapieaErrorResponseImpl(401, "Unauthorized.", PapieaError.Unauthorized)
             case PermissionDeniedError:
-                return new PapieaErrorImpl(403, "Permission denied.", PapieaErrorType.PermissionDenied)
+                return new PapieaErrorResponseImpl(403, "Permission denied.", PapieaError.PermissionDenied)
             case ConflictingEntityError:
                 let conflictingError = err as ConflictingEntityError
                 let metadata = conflictingError.existing_metadata
 
-                return new PapieaErrorImpl(409, `Conflicting Entity: ${metadata.uuid} has version ${metadata.spec_version}`, PapieaErrorType.ConflictingEntity)
+                return new PapieaErrorResponseImpl(409, `Conflicting Entity: ${metadata.uuid} has version ${metadata.spec_version}`, PapieaError.ConflictingEntity)
             default:
                 console.log(`Default handle got error: ${err.message}`)
-                return new PapieaErrorImpl(500, err.message, PapieaErrorType.ServerError)
+                return new PapieaErrorResponseImpl(500, err.message, PapieaError.ServerError)
         }
     }
 }

--- a/papiea-engine/src/errors/papiea_error_impl.ts
+++ b/papiea-engine/src/errors/papiea_error_impl.ts
@@ -4,7 +4,7 @@ import { ValidationError } from "./validation_error";
 import { ProcedureInvocationError } from "./procedure_invocation_error";
 import { PermissionDeniedError, UnauthorizedError } from "./permission_error";
 import { BadRequestError } from "./bad_request_error";
-import { PapieaErrorTypes } from "papiea-core";
+import { PapieaErrorType } from "papiea-core";
 
 
 export class PapieaErrorImpl implements PapieaError {
@@ -12,10 +12,10 @@ export class PapieaErrorImpl implements PapieaError {
         errors: { [key: string]: any }[],
         code: number
         message: string,
-        type: PapieaErrorTypes
+        type: PapieaErrorType
     }
 
-    constructor(code: number, errorMsg: string, type: PapieaErrorTypes, errors?: { [key: string]: any }[]) {
+    constructor(code: number, errorMsg: string, type: PapieaErrorType, errors?: { [key: string]: any }[]) {
         if (errors) {
             this.error = {
                 code,
@@ -48,34 +48,34 @@ export class PapieaErrorImpl implements PapieaError {
         let errorPayload: { message: string }[];
         switch (err.constructor) {
             case BadRequestError:
-                return new PapieaErrorImpl(400, "Bad Request", PapieaErrorTypes.BadRequest,
+                return new PapieaErrorImpl(400, "Bad Request", PapieaErrorType.BadRequest,
                     [{ message: err.message }])
             case ValidationError:
                 errorPayload = (err as ValidationError).errors.map(description => {
                     return { message: description }
                 })
-                return new PapieaErrorImpl(400, "Validation failed.", PapieaErrorTypes.Validation, errorPayload)
+                return new PapieaErrorImpl(400, "Validation failed.", PapieaErrorType.Validation, errorPayload)
             case ProcedureInvocationError:
-                return new PapieaErrorImpl((err as ProcedureInvocationError).status, "Procedure invocation failed.", PapieaErrorTypes.ProcedureInvocation, (err as ProcedureInvocationError).errors)
+                return new PapieaErrorImpl((err as ProcedureInvocationError).status, "Procedure invocation failed.", PapieaErrorType.ProcedureInvocation, (err as ProcedureInvocationError).errors)
             case EntityNotFoundError:
                 return new PapieaErrorImpl(
                     404,
                     "Entity not found.",
-                    PapieaErrorTypes.EntityNotFound,
+                    PapieaErrorType.EntityNotFound,
                     [{ message: `Entity with kind: ${(err as EntityNotFoundError).kind}, uuid: ${(err as EntityNotFoundError).uuid} not found` }],
                 )
             case UnauthorizedError:
-                return new PapieaErrorImpl(401, "Unauthorized.", PapieaErrorTypes.Unauthorized)
+                return new PapieaErrorImpl(401, "Unauthorized.", PapieaErrorType.Unauthorized)
             case PermissionDeniedError:
-                return new PapieaErrorImpl(403, "Permission denied.", PapieaErrorTypes.PermissionDenied)
+                return new PapieaErrorImpl(403, "Permission denied.", PapieaErrorType.PermissionDenied)
             case ConflictingEntityError:
                 let conflictingError = err as ConflictingEntityError
                 let metadata = conflictingError.existing_metadata
 
-                return new PapieaErrorImpl(409, `Conflicting Entity: ${metadata.uuid} has version ${metadata.spec_version}`, PapieaErrorTypes.ConflictingEntity)
+                return new PapieaErrorImpl(409, `Conflicting Entity: ${metadata.uuid} has version ${metadata.spec_version}`, PapieaErrorType.ConflictingEntity)
             default:
                 console.log(`Default handle got error: ${err.message}`)
-                return new PapieaErrorImpl(500, err.message, PapieaErrorTypes.ServerError)
+                return new PapieaErrorImpl(500, err.message, PapieaErrorType.ServerError)
         }
     }
 }

--- a/papiea-engine/src/main.ts
+++ b/papiea-engine/src/main.ts
@@ -17,7 +17,7 @@ import { S2SKeyUserAuthInfoExtractor } from "./auth/s2s";
 import { Authorizer, AdminAuthorizer, PerProviderAuthorizer } from "./auth/authz";
 import { ValidatorImpl } from "./validator";
 import { ProviderCasbinAuthorizerFactory } from "./auth/casbin";
-import { PapieaErrorImpl } from "./errors/papiea_error_impl";
+import { PapieaErrorResponseImpl } from "./errors/papiea_error_impl";
 import { SessionKeyAPI, SessionKeyUserAuthInfoExtractor } from "./auth/session_key"
 import { IntentfulContext } from "./intentful_core/intentful_context"
 import { AuditLogger } from "./audit_logging"
@@ -86,7 +86,7 @@ async function setUpApplication(): Promise<express.Express> {
         if (res.headersSent) {
             return next(err);
         }
-        const papieaError = PapieaErrorImpl.create(err);
+        const papieaError = PapieaErrorResponseImpl.create(err);
         res.status(papieaError.status)
         res.json(papieaError.toResponse())
         logger.error(papieaError, err.stack)


### PR DESCRIPTION
resolves #376 

It seems like we are still going for papiea-core package to be a DTO so I decided not to move errors there. Moreover, another reason is having flexibility in processing errors on papiea and on the client. Also exceptions should not be a contract, they should be a convenience, JSON structure of an error should be a contract